### PR TITLE
Prepare for fastboot 1.0 build change

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,14 +24,15 @@
   },
   "dependencies": {
     "bootstrap-datepicker": "^1.6.4",
-    "broccoli-funnel": "^1.1.0",
+    "broccoli-funnel": "^1.2.0",
     "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "^1.5.0",
     "ember-cli-babel": "^6.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
     "ember-ajax": "^3.0.0",
-    "ember-cli": "2.13.1",
+    "ember-cli": "2.14.0-beta.2",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-eslint": "^3.0.0",
     "ember-cli-htmlbars": "^1.1.1",


### PR DESCRIPTION
Hi there, ember-cli-fastboot 1.0 will have backwards incompatible changes. Please see doc here https://gist.github.com/kratiahuja/d22de0fb1660cf0ef58f07a6bcbf1a1c. The motivation for this change is documented here ember-fastboot/ember-cli-fastboot#387
The environment variable EMBER_CLI_FASTBOOTdoesn't exists any more in ember-cli-fastboot 1.0 build. I made the changes here, however the tests in this repo are already failing without my change. I have verified the build works with ember-cli-fastboot 1.0 I don't have enough context about your unit tests. Could you please verify on your side with proper use cases?
