### PR TITLE
[FIX] Re-select on second click – fixes #7

### DIFF
--- a/addon/components/bootstrap-datepicker.js
+++ b/addon/components/bootstrap-datepicker.js
@@ -42,13 +42,12 @@ export default Ember.Component.extend(DatepickerSupport, {
 
   forceParse: true,
 
-  focusOut() {
-    if (this.get('forceParse')) {
-      this._forceParse();
-    }
-  },
 
   _forceParse() {
+
+    if (!this.get('forceParse')) {
+      return;
+    }
 
     let date = null,
         format = this.get('format');

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -69,11 +69,16 @@ export default Ember.Mixin.create({
         this.sendAction('show');
       }).
       on('hide', () => {
+        this._forceParse();
         this.sendAction('hide');
       });
 
     this._updateDatepicker();
   }),
+
+  _forceParse() {
+    // not in support
+  },
 
   teardownBootstrapDatepicker: on('willDestroyElement', function() {
     this.$().datepicker('destroy');


### PR DESCRIPTION
execute forceParse only on datepicker hide-event, to prohibit focus problems.