### PR TITLE
Parse input on hide event to prohibit focus problems, fixes #7

### DIFF
--- a/addon/components/bootstrap-datepicker.js
+++ b/addon/components/bootstrap-datepicker.js
@@ -42,13 +42,12 @@ export default Ember.Component.extend(DatepickerSupport, {
 
   forceParse: true,
 
-  focusOut() {
-    if (this.get('forceParse')) {
-      this._forceParse();
-    }
-  },
 
   _forceParse() {
+
+    if (!this.get('forceParse')) {
+      return;
+    }
 
     let date = null,
         format = this.get('format');

--- a/addon/components/datepicker-support.js
+++ b/addon/components/datepicker-support.js
@@ -69,11 +69,16 @@ export default Ember.Mixin.create({
         this.sendAction('show');
       }).
       on('hide', () => {
+        this._forceParse();
         this.sendAction('hide');
       });
 
     this._updateDatepicker();
   }),
+
+  _forceParse() {
+    // not in support
+  },
 
   teardownBootstrapDatepicker: on('willDestroyElement', function() {
     this.$().datepicker('destroy');

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -158,7 +158,7 @@ test('works with input changes', function(assert) {
   `);
   this.$('input.ember-text-field')
     .val('2017-10-26')
-    .trigger('blur');
+    .trigger('hide');
 
   assert.ok(/Thu Oct 26 2017/.test(String(this.get('date'))));
   this.$('input.ember-text-field').datepicker('show');
@@ -174,7 +174,7 @@ test('works with european format', function(assert) {
 
   this.$('input.ember-text-field')
     .val('12.10.2017')
-    .trigger('blur');
+    .trigger('hide');
 
   assert.ok(/Thu Oct 12 2017/.test(String(this.get('date'))));
 });
@@ -188,7 +188,7 @@ test('works input shortened format', function(assert) {
 
   this.$('input.ember-text-field')
     .val('1.5.2017')
-    .trigger('blur');
+    .trigger('hide');
 
   assert.ok(/Mon May 01 2017/.test(String(this.get('date'))));
 });

--- a/tests/integration/components/bootstrap-datepicker-integration-test.js
+++ b/tests/integration/components/bootstrap-datepicker-integration-test.js
@@ -1,4 +1,5 @@
 import $ from 'jquery';
+import { run } from '@ember/runloop';
 import hbs from 'htmlbars-inline-precompile';
 import { moduleForComponent, test } from 'ember-qunit';
 
@@ -156,13 +157,16 @@ test('works with input changes', function(assert) {
   this.render(hbs`
     {{bootstrap-datepicker value=date}}
   `);
-  this.$('input.ember-text-field')
-    .val('2017-10-26')
-    .trigger('hide');
 
-  assert.ok(/Thu Oct 26 2017/.test(String(this.get('date'))));
-  this.$('input.ember-text-field').datepicker('show');
-  assert.equal($('.datepicker-switch').html(), 'October 2017');
+  run(() => {
+    this.$('input.ember-text-field')
+      .val('2017-10-26')
+      .trigger('hide');
+
+    assert.ok(/Thu Oct 26 2017/.test(String(this.get('date'))));
+    this.$('input.ember-text-field').datepicker('show');
+    assert.equal($('.datepicker-switch').html(), 'October 2017');
+  });
 });
 
 test('works with european format', function(assert) {
@@ -172,11 +176,13 @@ test('works with european format', function(assert) {
     {{bootstrap-datepicker value=date format="dd.mm.yyyy"}}
   `);
 
-  this.$('input.ember-text-field')
-    .val('12.10.2017')
-    .trigger('hide');
+  run(() => {
+    this.$('input.ember-text-field')
+      .val('12.10.2017')
+      .trigger('hide');
 
-  assert.ok(/Thu Oct 12 2017/.test(String(this.get('date'))));
+    assert.ok(/Thu Oct 12 2017/.test(String(this.get('date'))));
+  });
 });
 
 test('works input shortened format', function(assert) {
@@ -186,10 +192,12 @@ test('works input shortened format', function(assert) {
     {{bootstrap-datepicker value=date format="dd.mm.yyyy"}}
   `);
 
-  this.$('input.ember-text-field')
-    .val('1.5.2017')
-    .trigger('hide');
+  run(() => {
+    this.$('input.ember-text-field')
+      .val('1.5.2017')
+      .trigger('hide');
 
-  assert.ok(/Mon May 01 2017/.test(String(this.get('date'))));
+    assert.ok(/Mon May 01 2017/.test(String(this.get('date'))));
+  });
 });
 


### PR DESCRIPTION
hey, 

sorry I didn't check the tests.
I adjusted the integration tests, so hide event is triggered instead of blur event.
Hope this has no drawback ;) But working so far nicely in production.

