### PR TITLE
Check for init option on treeForVendor

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,10 @@ module.exports = {
       trees.push(vendorTree);
     }
 
+    if(!this.bootstrapDatepickerOptions) {
+      this.bootstrapDatepickerOptions = this.getConfig();
+    }
+
     var bootstrapDatepickerPath = this.bootstrapDatepickerOptions.path;
     var datePickerJsTree =  new Funnel(bootstrapDatepickerPath, {
       destDir: 'bootstrap-datepicker',

--- a/index.js
+++ b/index.js
@@ -93,7 +93,7 @@ module.exports = {
       trees.push(vendorTree);
     }
 
-    if(!this.bootstrapDatepickerOptions) {
+    if(!this.bootstrapDatepickerOptions && this.getConfig) {
       this.bootstrapDatepickerOptions = this.getConfig();
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bootstrap-datepicker",
-  "version": "2.0.8-alpha.1",
+  "version": "2.0.8",
   "description": "Datepicker component for Ember CLI based on bootstrap-datepicker. It doesn't have any external dependency except bootstrap-datepicker, supports popup and inline modes.",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-bootstrap-datepicker",
-  "version": "2.0.8",
+  "version": "2.0.8-alpha.1",
   "description": "Datepicker component for Ember CLI based on bootstrap-datepicker. It doesn't have any external dependency except bootstrap-datepicker, supports popup and inline modes.",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Fixes #2403

Checks if the options are setup to prevent checking for `path` on an undefined value.